### PR TITLE
modify udpSource to stream the sender's address with the message

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) kqr 2016
+Copyright (c) kqr 2016, Mihai Giurgeanu 2018
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/README.md
+++ b/README.md
@@ -4,16 +4,13 @@ Simple fire-and-forget style conduit parts (sources/sinks) for UDP traffic.
 
 Here's an example that sends a message to UDP port 8888 on localhost:
 
+    {-# LANGUAGE OverloadedStrings #-}
     import Conduit
     import Conduit.UDP
-    import Data.Text
-
-    message :: Text
-    message = "hello, world!\n"
 
     main :: IO ()
     main =
-        runConduitRes (yield message .| encodeUtf8C .| udpSink "127.0.0.1" 8888)
+        runConduitRes (yield "hello, world!\n" .| encodeUtf8C .| udpSink "127.0.0.1" 8888)
 
 Here's an example where we continuously receive messages on port 5666 on localhost:
 
@@ -22,10 +19,10 @@ Here's an example where we continuously receive messages on port 5666 on localho
 
     main :: IO ()
     main =
-        runConduitRes (udpSource "127.0.0.1" 5666 .| decodeUtf8C .| stdoutC)
+        runConduitRes (udpSourcePlain "127.0.0.1" 5666 500 .| stdoutC)
 
-Now, here's an example where we receive messages on port 8001, transform them to
-upper-case, and then send them on to port 8002.
+Now, here's an example where we receive messages on port 8001, encode them as hex
+digits, and then send them on to port 8002.
 
     import Conduit
     import Conduit.UDP
@@ -33,6 +30,9 @@ upper-case, and then send them on to port 8002.
 
     main :: IO ()
     main =
-        runConduitRes (udpSource "127.0.0.1" 8001 .| omapCE toUpper .| udpSink "127.0.0.1" 8002)
+        runConduitRes (udpSourcePlain "127.0.0.1" 8001 500 .| encodeBase16C  .| udpSink "127.0.0.1" 8002)
 
 Fun, huh? And simple!
+
+You can use `udpSource` to get the ip address of the sender together with the message in a
+pair `(ByteString, SockAddr)`

--- a/src/Conduit/UDP.hs
+++ b/src/Conduit/UDP.hs
@@ -1,38 +1,49 @@
 module Conduit.UDP
     ( udpSink
     , udpSource
+    , udpSourcePlain
+    , sinkSocket
+    , sinkIOSocket
+    , sourceSocket
+    , sourceIOSocket
     ) where
 
 import Data.ByteString (ByteString)
-import System.IO (IOMode(ReadMode, WriteMode), Handle)
 import qualified Network.Socket as Socket
 import Network.Socket
     ( Socket
     , SockAddr(SockAddrInet)
     , PortNumber
     , setSocketOption
-    , socketToHandle
     )
+
+import Network.Socket.ByteString
+   ( recvFrom
+    , send
+    )
+   
 import Conduit
     ( ConduitM
-    , MonadResource
-    , sinkIOHandle
-    , sourceIOHandle
+    , MonadIO
+    , await
+    , yield
+    , mapC
+    , liftIO
+    , (.|)
     )
+
+import Control.Monad.Trans.Resource
+    ( MonadResource
+    , allocate
+    )
+
+import Control.Monad (void)
 
 -- | A type to distinguish when we want to read and write from sockets,
 -- simplifying the implementation
 data SocketType
-    = SourceSocket -- ^ source socket, should 'Network.Socket.bind' and have 'System.IO.ReadMode'
-    | SinkSocket -- ^ sink socket, should 'Network.Socket.connect' and have 'System.IO.WriteMode'
-
--- | Get the correct 'System.IO.IOMode' for handles representing either source
--- sockets or sink sockets
-ioMode :: SocketType -> IOMode
-ioMode socketType =
-    case socketType of
-        SourceSocket -> ReadMode
-        SinkSocket -> WriteMode
+    = SourceSocket -- ^ source socket, should 'Network.Socket.bind'
+    | SinkSocket   -- ^ sink socket, should 'Network.Socket.connect'
 
 -- | Use either 'Network.Socket.bind' or 'Network.Socket.connect' depending on the 'SocketType'
 socketMode :: SocketType -> Socket -> SockAddr -> IO ()
@@ -50,34 +61,91 @@ udpSink
     :: (MonadResource m)
     => String -- ^ address to destination
     -> PortNumber -- ^ port number on destination
-    -> ConduitM ByteString o m () -- ^ Can be viewed as a @'Data.Conduit.Sink' ByteString@
+    -> ConduitM ByteString o m ()
 udpSink host port =
-    sinkIOHandle (udpHandle host port SinkSocket)
+    sinkIOSocket (udpSocket host port SinkSocket)
 
 
 -- | Fire-and-forget style UDP source. It will attempt to listen on the
 -- specified interface and port, and if it succeeds it can read contents
--- being sent to that interface and port. Must be used with
+-- being sent to that interface and port.
+-- It streams a pair of (message, source-address) allowing the downstream
+-- to know who sent the message. 
+-- Must be used with
 -- 'Data.Conduit.runConduitRes', since it uses a finite resource (sockets)
 udpSource
     :: (MonadResource m)
-    => String -- ^ address to bind to
-    -> PortNumber -- ^ port number to bind to
-    -> ConduitM i ByteString m () -- ^ Can be viewed as a @MonadIO m => 'Data.Conduit.Source' m ByteString@
-udpSource host port =
-    sourceIOHandle (udpHandle host port SourceSocket)
+    => String                                   -- ^ address to bind to
+    -> PortNumber                               -- ^ port number to bind to
+    -> Int                                      -- ^ the maximum size of a datagram
+    -> ConduitM i (ByteString, SockAddr) m ()
+udpSource host port sz =
+    sourceIOSocket (udpSocket host port SourceSocket) sz
+
+
+-- | Variant of 'udpSource' streaming only the 'ByteString' messages, without
+-- the address of the message source.
+udpSourcePlain
+    :: (MonadResource m)
+    => String                           -- ^ address to bind to
+    -> PortNumber                       -- ^ port number to bind to
+    -> Int                              -- ^ the maximum size of a datagram
+    -> ConduitM i ByteString m ()
+udpSourcePlain host port sz =
+    udpSource host port sz .| mapC fst
 
 
 -- | Given a host, port and 'SocketType', create a socket and
 -- 'Network.Socket.connect' or 'Network.Socket.bind' to the address pair.
-udpHandle
+udpSocket
     :: String -- ^ IP address to host
     -> PortNumber
     -> SocketType
-    -> IO Handle
-udpHandle host port socketType = do
+    -> IO Socket
+udpSocket host port socketType =  do
     socket <- Socket.socket Socket.AF_INET Socket.Datagram Socket.defaultProtocol
     setSocketOption socket Socket.ReusePort 1
     address <- Socket.inet_addr host
     socketMode socketType socket (SockAddrInet port address)
-    socketToHandle socket (ioMode socketType)
+    return socket
+
+-- | Stream all incoming data to the given connected 'Socket'. Note that this function will
+-- not automatically close the 'Socket' when processing completes.
+sinkSocket :: (MonadIO m) => Socket -> ConduitM ByteString o m ()
+sinkSocket s = do
+  mmsg <- await
+  case mmsg of
+    Just msg -> do
+      void $ liftIO $ send s msg -- since we send datagrams, can't use sendAll; ignore the value returned by send
+      sinkSocket s
+    Nothing -> return ()
+
+-- | An alternative to 'sinkSocket'. Instead of taking a pre-opened 'Socket', it
+-- takes an action that returns a connected 'Socket' , so that it can open it
+-- only when needed and close it as soon as possible.
+sinkIOSocket :: MonadResource m => IO Socket -> ConduitM ByteString o m ()
+sinkIOSocket connectAction = do
+  (_, s) <- allocate connectAction Socket.close         
+  sinkSocket s
+
+-- | Stream the contents of a bound 'Socket' as binary data. Note that this function will not automatically
+-- close the 'Socket' when processing completes, since it did not acquire the 'Socket' in the first place.
+sourceSocket :: MonadIO m
+             => Socket                                  -- ^ the socket
+             -> Int                                     -- ^ maximum length of datagram to receive
+             -> ConduitM i (ByteString, SockAddr) m ()  -- ^ streams downstream the received data and sender address
+sourceSocket s sz = do
+  msg <- liftIO $ recvFrom s sz
+  yield msg
+  sourceSocket s sz
+
+-- | An alternative to sourceSocket. Instead of taking a pre-bound 'Socket', it takes an action that opens and
+-- binds a Socket, so that it can open it only when needed and close it as soon as possible.
+sourceIOSocket :: MonadResource m
+               => IO Socket                                     -- ^ the action that creates the socket
+               -> Int                                           -- ^ maximum length of datagram to receive
+               -> ConduitM i (ByteString, SockAddr) m ()        -- ^ streams downstream the received data and the sender address
+sourceIOSocket bindAction sz = do
+  (_, s) <- allocate bindAction Socket.close
+  sourceSocket s sz
+

--- a/udp-conduit.cabal
+++ b/udp-conduit.cabal
@@ -1,5 +1,5 @@
 name:                udp-conduit
-version:             0.1.0.4
+version:             0.2.0.0
 synopsis:            Simple fire-and-forget conduit UDP wrappers
 description:
     `udp-conduit` provides simple wrappers to get fire-and-forget UDP sinks
@@ -9,7 +9,8 @@ license:             ISC
 license-file:        LICENSE
 author:              kqr
 maintainer:          k@rdw.se
-copyright:           (c) 2016 kqr
+copyright:           (c) 2016 kqr,
+                         2018 Mihai Giurgeanu
 category:            Data, Conduit
 build-type:          Simple
 extra-source-files:  README.md

--- a/udp-conduit.cabal
+++ b/udp-conduit.cabal
@@ -23,6 +23,7 @@ library
                      , network
                      , bytestring < 0.11
                      , conduit-combinators >= 1.1 && < 1.2
+                     , resourcet
   default-language:    Haskell2010
 
 source-repository head


### PR DESCRIPTION
This pull request implements the proposal in the issue #3. It also adds a new `Int` parameter to `udpSource` and `udpSourcePlain` setting the maximum size of datagram. I think, being about datagrams, the protocol designer should know the maximum size of the datagram and so, it will be faster to make a single call to `recvFrom` and not to test if there is some more data to come. 